### PR TITLE
Solving compilation error due to missing intellij dependency

### DIFF
--- a/agentv-commander/build.sbt
+++ b/agentv-commander/build.sbt
@@ -32,6 +32,8 @@ libraryDependencies += "ch.qos.logback" % "logback-core" % "1.1.1"
 
 libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.1.1"
 
+libraryDependencies += "com.intellij" % "forms_rt" % "7.0.3"
+
 
 autoCompilerPlugins := true
 


### PR DESCRIPTION
I have added into the dependency the intellij missing lib
https://github.com/PrismTech/agentv/issues/2

Change-Id: Idc63f22709cc6fd7ece5d6c0fe14abc7b0906215
Signed-off-by: Francois Le Fevre  flf.mib@gmail.com
